### PR TITLE
To support Windows the output lib was moved

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -25,5 +25,5 @@ jobs:
 
     - name: Import python library
       run: |
-        cd build
+        cd build/tolc
         python3 -c "import Math"

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -23,5 +23,5 @@ jobs:
 
     - name: Import python library
       run: |
-        cd build
+        cd build/tolc
         python3 -c "import Math"

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ $ cmake --build build
 You should now be able to start using the `C++` library `Math` from `python`:
 
 ```shell
-$ cd build
+$ cd build/tolc
 $ python3
 >>> import Math
 >>> Math.Demo.merge({"tolc": 0}, {"demo": 1})


### PR DESCRIPTION
As far as I understand the MSVC linker does not by default allow two libraries with the same name to be outputted to the same directory. This is what happens with Math.lib and the corresponding Math python library. To avoid this the output directory for targets created by tolc is now build/tolc